### PR TITLE
Implemented NfcV Tag check

### DIFF
--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/NfcHandler.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/NfcHandler.kt
@@ -104,7 +104,7 @@ private fun Tag.read(callback: (Map<*, *>) -> Unit) {
     val isNfcV = this.techList.contains("android.nfc.tech.NfcV")
     // Get the ID from the tag, reverse only if it's NfcV (ISO 15693)
     val id = if (isNfcV) {
-        // reverse array to convert to big-endian to match CoreNFC implementation of ISO 15693
+        // reverse array to convert to little-endian to match CoreNFC implementation of ISO 15693
         this.getId().reversedArray().bytesToHexString()
     } else {
         this.getId().bytesToHexString()

--- a/android/src/main/kotlin/it/matteocrippa/flutternfcreader/NfcHandler.kt
+++ b/android/src/main/kotlin/it/matteocrippa/flutternfcreader/NfcHandler.kt
@@ -105,9 +105,9 @@ private fun Tag.read(callback: (Map<*, *>) -> Unit) {
     // Get the ID from the tag, reverse only if it's NfcV (ISO 15693)
     val id = if (isNfcV) {
         // reverse array to convert to big-endian to match CoreNFC implementation of ISO 15693
-        this.id.reversedArray().bytesToHexString()
+        this.getId().reversedArray().bytesToHexString()
     } else {
-        this.id.bytesToHexString()
+        this.getId().bytesToHexString()
     }
     if (ndef == null) {
         callback(mapOf(kId to id, kContent to null, kError to "failed to get NDEF", kStatus to "error"))


### PR DESCRIPTION
Implemented a way to see if the nfc tag is NfcV (ISO 15693) or not on android devices.

This is becouse we want to reverse the array if its a NfcV tag to match it with how IOS handles it.

We dont want to reverse it if its NfcA for an example. Becouse android and IOS handles the reading the same.